### PR TITLE
fix create user action

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 // Is there a better way to do that in Go?
 const (
-	userNameKey   = "OK_USER_NAME"
+	usernameKey   = "OK_USERNAME"
 	passwordKey   = "OK_PASSWORD"
 	jenkinsUrlKey = "OK_JENKINS_URL"
 	giteaUrlKey   = "OK_GITEA_URL"
@@ -69,5 +69,5 @@ func cleanUrl(remoteKey string, remotePath string) string {
 	}
 
 	// alternatively use StringBuilder
-	return fmt.Sprintf("%s://%s:%s%s\n", url.Scheme, url.Hostname(), url.Port(), path.Clean(url.EscapedPath()))
+	return fmt.Sprintf("%s://%s:%s%s", url.Scheme, url.Hostname(), url.Port(), path.Clean(url.EscapedPath()))
 }

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -14,8 +14,8 @@ var userCmd = &cobra.Command{
 }
 
 func init() {
-	if _, ok := os.LookupEnv(userNameKey); !ok {
-		fmt.Printf("%s is not set but is required to work.\n", userNameKey)
+	if _, ok := os.LookupEnv(usernameKey); !ok {
+		fmt.Printf("%s is not set but is required to work.\n", usernameKey)
 		os.Exit(1)
 	}
 

--- a/cmd/usercreate.go
+++ b/cmd/usercreate.go
@@ -12,38 +12,38 @@ import (
 )
 
 var userCreateCmd = &cobra.Command{
-	Use:   "create --email <email> --loginName <loginName> --password <password>",
+	Use:   "create --email <email> --username <username> --password <password>",
 	Short: "", // TODO: add Short and Long
 	Long:  "",
 	Run:   userCreate,
 }
 
 var (
-	email     string
-	loginName string
-	password  string
+	email    string
+	username string
+	password string
 )
 
 type createUserOption struct {
 	Email              string `json:"email"`
-	LoginName          string `json:"login_name"`
+	Username           string `json:"username"`
 	MustChangePassword bool   `json:"must_change_password"`
 	Password           string `json:"password"`
 }
 
 func init() {
 	userCreateCmd.Flags().StringVarP(&email, "email", "e", "", "User's email address")
-	userCreateCmd.Flags().StringVarP(&loginName, "loginName", "l", "", "User's login name")
+	userCreateCmd.Flags().StringVarP(&username, "username", "u", "", "User's login name")
 	userCreateCmd.Flags().StringVarP(&password, "password", "p", "", "User's password")
 	_ = userCreateCmd.MarkFlagRequired("email")
-	_ = userCreateCmd.MarkFlagRequired("loginName")
+	_ = userCreateCmd.MarkFlagRequired("username")
 	_ = userCreateCmd.MarkFlagRequired("password")
 }
 
 func userCreate(cmd *cobra.Command, _ []string) {
 	u := createUserOption{
 		Email:              email,
-		LoginName:          loginName,
+		Username:           username,
 		MustChangePassword: false,
 		Password:           password,
 	}
@@ -57,12 +57,13 @@ func userCreate(cmd *cobra.Command, _ []string) {
 
 	req, err := http.NewRequest("POST", userCreateUrl(), bytes.NewBuffer(b))
 	if err != nil {
-		fmt.Printf("An error occurred during  request creation: %s\n", err)
+		fmt.Printf("An error occurred during request creation: %s\n", err)
 		return
 	}
 
 	// TODO: perhaps using a token would be better? See /admin​/users​/{username}​/keys route
-	req.SetBasicAuth(os.Getenv(userNameKey), os.Getenv(passwordKey))
+	req.SetBasicAuth(os.Getenv(usernameKey), os.Getenv(passwordKey))
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -81,6 +82,8 @@ func userCreate(cmd *cobra.Command, _ []string) {
 	case 422:
 		// api validation error; this should not happen except there are changes in the api
 		fmt.Printf("Request failed (422). The Gitea api may have changed. %s\n", string(respBody))
+	default:
+		fmt.Printf("Request failed (%d). %s\n", resp.StatusCode, string(respBody))
 	}
 }
 

--- a/cmd/userlist.go
+++ b/cmd/userlist.go
@@ -25,7 +25,7 @@ func userList(_ *cobra.Command, _ []string) {
 	}
 
 	// TODO: handle missing env var
-	req.SetBasicAuth(os.Getenv(userNameKey), os.Getenv(passwordKey))
+	req.SetBasicAuth(os.Getenv(usernameKey), os.Getenv(passwordKey))
 
 	client := &http.Client{}
 


### PR DESCRIPTION
I made a mistake by using `login_name` instead of `username` which lead to a failure of the create rest call. I also renamed `OK_USER_NAME` since the whitespace is wrong.