### PR TITLE
Add config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,14 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Is there a better way to do that in Go?
-const (
-	usernameKey   = "OK_USERNAME"
-	passwordKey   = "OK_PASSWORD"
-	jenkinsUrlKey = "OK_JENKINS_URL"
-	giteaUrlKey   = "OK_GITEA_URL"
-)
-
 var config okconfig.Config
 
 var rootCmd = &cobra.Command{
@@ -48,23 +40,10 @@ func init() {
 	config = okconfig.NewConfig()
 }
 
-// Checks if environment variables for the external server, user name and password are set.
-func checkEnv() {
-	check := func(key string) {
-		if _, ok := os.LookupEnv(key); !ok {
-			fmt.Printf("%s is not set but is required to work.\n", key)
-			os.Exit(1)
-		}
-	}
-
-	check(jenkinsUrlKey)
-	check(giteaUrlKey)
-}
-
 // Creates a clean url without any trailing slashes or special characters.
-func cleanUrl(remotePath string) string {
+func cleanUrl(remoteKey string, remotePath string) string {
 	// TODO: differentiate between Gitea and Jenkins backend
-	rawURL := config.GiteaURL + remotePath
+	rawURL := fmt.Sprintf("%s%s", remoteKey, remotePath)
 
 	url, err := neturl.Parse(rawURL)
 	if err != nil {
@@ -76,6 +55,5 @@ func cleanUrl(remotePath string) string {
 		fmt.Printf("Invalid server type %s\n, only http is supported.", url.Scheme)
 	}
 
-	// alternatively use StringBuilder
 	return fmt.Sprintf("%s://%s:%s%s", url.Scheme, url.Hostname(), url.Port(), path.Clean(url.EscapedPath()))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"path"
 
+	// config collides with struct in package cmd
+	okconfig "github.com/cwansart/ok-cli/internal/config"
+
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +19,8 @@ const (
 	jenkinsUrlKey = "OK_JENKINS_URL"
 	giteaUrlKey   = "OK_GITEA_URL"
 )
+
+var config okconfig.Config
 
 var rootCmd = &cobra.Command{
 	Use:   "ok <command> <action> [parameters]",
@@ -40,7 +45,7 @@ func init() {
 	userCmd.AddCommand(userCreateCmd)
 	userCmd.AddCommand(userListCmd)
 
-	checkEnv()
+	config = okconfig.NewConfig()
 }
 
 // Checks if environment variables for the external server, user name and password are set.
@@ -57,15 +62,13 @@ func checkEnv() {
 }
 
 // Creates a clean url without any trailing slashes or special characters.
-func cleanUrl(remoteKey string, remotePath string) string {
+func cleanUrl(remotePath string) string {
 	// TODO: differentiate between Gitea and Jenkins backend
-	rawURL := os.Getenv(remoteKey) + remotePath
-	url, err := neturl.Parse(rawURL)
+	rawURL := config.GiteaURL + remotePath
 
-	// TODO: proper error handling
+	url, err := neturl.Parse(rawURL)
 	if err != nil {
-		fmt.Printf("An error occured: %s\n", err)
-		os.Exit(1)
+		fmt.Errorf("Could not parse URL: %s\n", err)
 	}
 
 	// TODO: add https support and disable http

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	neturl "net/url"
 	"os"
 	"path"
+	"strings"
 
 	// 'config' collides with name declared in this package
 	okconfig "github.com/cwansart/ok-cli/internal/config"
@@ -55,8 +56,17 @@ func cleanUrl(remoteKey string, remotePath string) string {
 		fmt.Printf("Invalid server type %s\n, only http is supported.", url.Scheme)
 	}
 
-	if len(url.Port()) == 0 {
-		return fmt.Sprintf("%s://%s%s", url.Scheme, url.Hostname(), path.Clean(url.EscapedPath()))
+	// is correct, but doesnt look good
+	var urlBuilder strings.Builder
+
+	urlBuilder.WriteString(url.Scheme)
+	urlBuilder.WriteString("://")
+	urlBuilder.WriteString(url.Hostname())
+	if len(url.Port()) != 0 {
+		urlBuilder.WriteString(":")
+		urlBuilder.WriteString(url.Port())
 	}
-	return fmt.Sprintf("%s://%s:%s%s", url.Scheme, url.Hostname(), url.Port(), path.Clean(url.EscapedPath()))
+	urlBuilder.WriteString(path.Clean(url.EscapedPath()))
+
+	return urlBuilder.String()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path"
 
-	// config collides with struct in package cmd
+	// 'config' collides with name declared in this package
 	okconfig "github.com/cwansart/ok-cli/internal/config"
 
 	"github.com/spf13/cobra"
@@ -55,5 +55,8 @@ func cleanUrl(remoteKey string, remotePath string) string {
 		fmt.Printf("Invalid server type %s\n, only http is supported.", url.Scheme)
 	}
 
+	if len(url.Port()) == 0 {
+		return fmt.Sprintf("%s://%s%s", url.Scheme, url.Hostname(), path.Clean(url.EscapedPath()))
+	}
 	return fmt.Sprintf("%s://%s:%s%s", url.Scheme, url.Hostname(), url.Port(), path.Clean(url.EscapedPath()))
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	okconfig "github.com/cwansart/ok-cli/internal/config"
+	"github.com/magiconair/properties/assert"
+	"testing"
+)
+
+func TestCleanURL(t *testing.T) {
+	var testData = []struct {
+		config        okconfig.Config
+		path          string
+		correctResult string
+	}{
+		{
+			createTestConfig("", "", "http://localhost", ""),
+			"/api/v1/admin/users",
+			"http://localhost/api/v1/admin/users",
+		},
+		// add more tests here
+	}
+
+	for _, tt := range testData {
+		got := cleanUrl(tt.config.GiteaURL, tt.path)
+		assert.Equal(t, got, tt.correctResult)
+	}
+}
+
+func createTestConfig(username, password, giteaURL, jenkinsURL string) okconfig.Config {
+	return okconfig.Config{
+		Username:   username,
+		Password:   password,
+		JenkinsURL: jenkinsURL,
+		GiteaURL:   giteaURL,
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestCleanURL(t *testing.T) {
 	var testData = []struct {
-		config        okconfig.Config
-		path          string
-		correctResult string
+		config okconfig.Config
+		path   string
+		want   string
 	}{
 		{
 			createTestConfig("", "", "http://localhost", ""),
@@ -20,9 +20,9 @@ func TestCleanURL(t *testing.T) {
 		// add more tests here
 	}
 
-	for _, tt := range testData {
-		got := cleanUrl(tt.config.GiteaURL, tt.path)
-		assert.Equal(t, got, tt.correctResult)
+	for _, td := range testData {
+		got := cleanUrl(td.config.GiteaURL, td.path)
+		assert.Equal(t, got, td.want)
 	}
 }
 

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -9,15 +9,3 @@ var userCmd = &cobra.Command{
 	Short: "Manage users",
 	Long:  "Long",
 }
-
-func init() {
-	//if _, ok := os.LookupEnv(usernameKey); !ok {
-	//	fmt.Printf("%s is not set but is required to work.\n", usernameKey)
-	//	os.Exit(1)
-	//}
-	//
-	//if _, ok := os.LookupEnv(passwordKey); !ok {
-	//	fmt.Printf("%s is not set but is required to work.\n", passwordKey)
-	//	os.Exit(1)
-	//}
-}

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -14,13 +11,13 @@ var userCmd = &cobra.Command{
 }
 
 func init() {
-	if _, ok := os.LookupEnv(usernameKey); !ok {
-		fmt.Printf("%s is not set but is required to work.\n", usernameKey)
-		os.Exit(1)
-	}
-
-	if _, ok := os.LookupEnv(passwordKey); !ok {
-		fmt.Printf("%s is not set but is required to work.\n", passwordKey)
-		os.Exit(1)
-	}
+	//if _, ok := os.LookupEnv(usernameKey); !ok {
+	//	fmt.Printf("%s is not set but is required to work.\n", usernameKey)
+	//	os.Exit(1)
+	//}
+	//
+	//if _, ok := os.LookupEnv(passwordKey); !ok {
+	//	fmt.Printf("%s is not set but is required to work.\n", passwordKey)
+	//	os.Exit(1)
+	//}
 }

--- a/cmd/usercreate.go
+++ b/cmd/usercreate.go
@@ -46,7 +46,6 @@ func userCreate(_ *cobra.Command, _ []string) {
 	go createOnJenkins(s)
 
 	g, j := <-s
-	// @Max: does this work?
 	if !g || !j {
 		// TODO: undo changes if one fails
 	}
@@ -60,11 +59,10 @@ func createOnGitea(s chan bool) {
 		Password:           password,
 	}
 
-	// TODO: change to decoder?
 	b, err := json.Marshal(u)
 	if err != nil {
-		fmt.Printf("An error occurred during marshalling:  %s\n", err)
-		os.Exit(1)
+		fmt.Errorf("An error occurred during marshalling:  %s\n", err)
+		return
 	}
 
 	req, err := http.NewRequest("POST", giteaUserCreateUrl(), bytes.NewBuffer(b))
@@ -80,7 +78,7 @@ func createOnGitea(s chan bool) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Printf("An error occurred during request: %s\n", err)
+		fmt.Errorf("An error occurred during request: %s\n", err)
 		return
 	}
 
@@ -108,5 +106,5 @@ func createOnJenkins(s chan bool) {
 }
 
 func giteaUserCreateUrl() string {
-	return cleanUrl(giteaUrlKey, "/api/v1/admin/users")
+	return cleanUrl("/api/v1/admin/users")
 }

--- a/cmd/usercreate.go
+++ b/cmd/usercreate.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/spf13/cobra"
 	"io/ioutil"
 	"net/http"
-	"os"
-
-	"github.com/spf13/cobra"
 )
 
 var userCreateCmd = &cobra.Command{
@@ -72,7 +70,7 @@ func createOnGitea(s chan bool) {
 	}
 
 	// TODO: perhaps using a token would be better? See /admin​/users​/{username}​/keys route
-	req.SetBasicAuth(os.Getenv(usernameKey), os.Getenv(passwordKey))
+	req.SetBasicAuth(config.Username, config.Password)
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
@@ -106,5 +104,5 @@ func createOnJenkins(s chan bool) {
 }
 
 func giteaUserCreateUrl() string {
-	return cleanUrl("/api/v1/admin/users")
+	return cleanUrl(config.GiteaURL, "/api/v1/admin/users")
 }

--- a/cmd/userlist.go
+++ b/cmd/userlist.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
 	"io/ioutil"
 	"net/http"
-	"os"
-
-	"github.com/spf13/cobra"
 )
 
 var userListCmd = &cobra.Command{
@@ -25,7 +23,7 @@ func userList(_ *cobra.Command, _ []string) {
 	}
 
 	// TODO: handle missing env var
-	req.SetBasicAuth(os.Getenv(usernameKey), os.Getenv(passwordKey))
+	req.SetBasicAuth(config.Username, config.Password)
 
 	client := &http.Client{}
 
@@ -44,5 +42,5 @@ func userList(_ *cobra.Command, _ []string) {
 func userListUrl() string {
 	// TODO: give an option to get users from Jenkins or Gitea. Or perhaps get them from both?
 	// Perhaps we should extract the url key into structs to enable Gitea, GitLab and other implementations.
-	return cleanUrl("/api/v1/admin/users")
+	return cleanUrl(config.GiteaURL, "/api/v1/admin/users")
 }

--- a/cmd/userlist.go
+++ b/cmd/userlist.go
@@ -44,5 +44,5 @@ func userList(_ *cobra.Command, _ []string) {
 func userListUrl() string {
 	// TODO: give an option to get users from Jenkins or Gitea. Or perhaps get them from both?
 	// Perhaps we should extract the url key into structs to enable Gitea, GitLab and other implementations.
-	return cleanUrl(giteaUrlKey, "/api/v1/admin/users")
+	return cleanUrl("/api/v1/admin/users")
 }

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cwansart/ok-cli
 go 1.13
 
 require (
+	github.com/magiconair/properties v1.8.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// Config contains all the env var which the user set
+type Config struct {
+	Username   string
+	Password   string
+	JenkinsURL string
+	GiteaURL   string
+}
+
+func NewConfig() Config {
+	return Config{
+		Username:   getEnvVar("OK_USERNAME"),
+		Password:   getEnvVar("OK_PASSWORD"),
+		JenkinsURL: getEnvVar("OK_JENKINS_URL"),
+		GiteaURL:   getEnvVar("OK_GITEA_URL"),
+	}
+}
+
+func getEnvVar(key string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		fmt.Errorf("Could not find env %s\n", key)
+	}
+	return val
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"os"
+	"testing"
+)
+
+func TestGetEnvVar(t *testing.T) {
+	if err := os.Setenv("KEY", "value"); err != nil {
+		t.Fatalf("Could not set env var: %s", err)
+	}
+	envVar := getEnvVar("KEY")
+	assert.Equal(t, "value", envVar)
+
+	envVar = getEnvVar("NOT_EXISTING_KEY")
+	assert.Equal(t, "", envVar)
+}
+
+func TestNewConfig(t *testing.T) {
+	setEnv(t, "OK_USERNAME", "admin")
+	setEnv(t, "OK_PASSWORD", "admin")
+	setEnv(t, "OK_JENKINS_URL", "localhost:8080")
+	setEnv(t, "OK_GITEA_URL", "localhost:8081")
+
+	c := NewConfig()
+
+	assert.Equal(t, "admin", c.Username)
+	assert.Equal(t, "admin", c.Password)
+	assert.Equal(t, "localhost:8080", c.JenkinsURL)
+	assert.Equal(t, "localhost:8081", c.GiteaURL)
+}
+
+func setEnv(t *testing.T, key, value string) {
+	err := os.Setenv(key, value)
+	if err != nil {
+		t.Fatalf("could not set env var: %s", err)
+	}
+}


### PR DESCRIPTION
Vorher wurden die env vars geholt, wenn die gebraucht wurden.
Ich hab jetzt eine Config erstellt, die am Anfang alle env vars sich holt. Dann können sich die ganzen Funktionen sich über die Config die Werte holen.

Man könnte es nochmal ändern, da die Config jetzt noch global ist(vllt als Parameter übergeben)